### PR TITLE
Link to new "asciiflow2" issues page in new tab.

### DIFF
--- a/index.html
+++ b/index.html
@@ -541,7 +541,7 @@ textarea {
         <div class="info-icon-file redo-image"></div><div class="info-description">Redo. <br><span>Too many Undo's? Redo!</span></div><br>
         <br>
 
-        <div>File issues as bugs <a href="https://github.com/lewish/asciiflow2-issues/issues">here</a>.</div><br>
+        <div>File issues as bugs <a href="https://github.com/lewish/asciiflow2/issues" target="_blank">here</a>.</div><br>
         <div>Return to the original <a href="http://stable.ascii-flow.appspot.com/">ASCIIFlow</a>.</div><br>
         Developed by <a href="https://plus.google.com/+LewisHemens/about">Lewis</a>, Designed by <a href="mailto:info@samirvine.co.uk">Sam</a> and <a href="mailto:ryangilbanks@gmail.com">Ryan</a>.
         <br>


### PR DESCRIPTION
Current site links to the deprecated issues page instead of the new location.
We load the github page into new tab (target attribute) so that current drawing is not destroyed.