### PR TITLE
Add very simple electron-based desktop app wrapper

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,30 @@
+// Very simple electron wrapper script that allows us to use asciiflow2 as a desktop application
+
+const electron = require('electron')
+const app = electron.app
+const BrowserWindow = electron.BrowserWindow
+
+const path = require('path')
+const url = require('url')
+
+let mainWindow;
+
+function createWindow () {
+  mainWindow = new BrowserWindow({width: 800, height: 600, icon: path.join(__dirname, 'images', 'favicon.png')});
+  mainWindow.setMenu(null);
+  mainWindow.loadURL(url.format({
+    pathname: path.join(__dirname, 'index.html'),
+    protocol: 'file:',
+    slashes: true
+  }))
+
+  mainWindow.on('closed', function () {
+    mainWindow = null
+  })
+}
+
+app.on('ready', createWindow)
+
+app.on('window-all-closed', function () {
+    app.quit()
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "asciiflow2",
+  "main": "index.js",
+  "icon": "images/favicon.png",
+  "scripts": {
+      "start": "electron ."
+  }
+}
+


### PR DESCRIPTION
So one could run `electron .` to have asciiflow2 as its own desktop app