### PR TITLE
fixed typos in state.js

### DIFF
--- a/js-lib/state.js
+++ b/js-lib/state.js
@@ -320,7 +320,7 @@ export default class State {
    */
   fromText(value, offset) {
     var lines = value.split('\n');
-    var middle = new ascii.Vector(0, Math.round(lines.length / 2));
+    var middle = new Vector(0, Math.round(lines.length / 2));
     for (var j = 0; j < lines.length; j++) {
       middle.x = Math.max(middle.x, Math.round(lines[j].length / 2));
     }
@@ -331,10 +331,10 @@ export default class State {
         // Convert special output back to special chars.
         // TODO: This is a horrible hack, need to handle multiple special chars
         // correctly and preserve them through line drawing etc.
-        if (SPECIAL_VALUES.indexOf(char)  != -1) {
-          char = SPECIAL_VALUE;
+        if (c.SPECIAL_VALUES.indexOf(char)  != -1) {
+          char = c.SPECIAL_VALUE;
         }
-        this.drawValue(new ascii.Vector(i, j).add(offset).subtract(middle), char);
+        this.drawValue(new Vector(i, j).add(offset).subtract(middle), char);
       }
     }
   }


### PR DESCRIPTION
asciiflow2 was able to compile, but it didn't function properly.

I admit, I know nothing about javascript, specifically. But, it seems like these may be typos. My machine complained about them. They broke the compiled script (couldn't actually do anything to the character field). They appear to differ from the rest of the code. These changes fixed all that.