### PR TITLE
Add support for multi-byte character

### DIFF
--- a/index.html
+++ b/index.html
@@ -476,6 +476,13 @@ textarea {
   animation-name: fadeOut;
 }
 
+.output-raw {
+  position: absolute;
+  left: 0px;
+  bottom: 0px;
+  margin: 7px;
+}
+
 </style>
 </head>
 <body>
@@ -512,6 +519,10 @@ textarea {
 <div id="export-button-dialog" class="dialog">
     <textarea readonly id="export-area"></textarea>
     <div class="dialog-button-bar">
+        <div class="output-raw">
+            <input type="checkbox" id="output-raw" />
+            <label for="output-raw">padding</label>
+        </div>
         <button class="close-dialog-button">Close</button>
   </div>
 </div>

--- a/js-lib/controller.js
+++ b/js-lib/controller.js
@@ -123,6 +123,10 @@ export default class Controller {
       this.handleFileButton(e.target.id);
     });
 
+    $('#output-raw').click(e => {
+      this.handleFileButton('export-button');
+    });
+
     $('button.close-dialog-button').click(e => {
       $('.dialog').removeClass('visible');
     });
@@ -223,7 +227,8 @@ export default class Controller {
     }
 
     if (id == 'export-button') {
-      $('#export-area').val(this.state.outputText());
+      var raw = Boolean($("#output-raw").prop("checked"));
+      $('#export-area').val(this.state.outputText(null, raw));
       $('#export-area').select();
     }
     if (id == 'clear-button') {

--- a/js-lib/draw/utils.js
+++ b/js-lib/draw/utils.js
@@ -55,7 +55,7 @@ export function drawLine(
  */
 export function drawText(state, position, text) {
   let x = 0, y = 0;
-  for (const char of text) {
+  for (const char of State.paddingText(text)) {
     if (char == '\n') {
       y++;
       x = 0;

--- a/js-lib/state.js
+++ b/js-lib/state.js
@@ -274,9 +274,10 @@ export default class State {
   /**
    * Outputs the entire contents of the diagram as text.
    * @param {Box=} opt_box
+   * @param {boolean} raw
    * @return {string}
    */
-  outputText(opt_box) {
+  outputText(opt_box, raw = false) {
     // Find the first/last cells in the diagram so we don't output everything.
     var start = new Vector(Number.MAX_VALUE, Number.MAX_VALUE);
     var end = new Vector(-1, -1);
@@ -308,7 +309,7 @@ export default class State {
       // Trim end whitespace.
       output += line.replace(/\s+$/, '') + '\n';
     }
-    return output;
+    return raw ? output : State.unpaddingText(output);
   }
 
   /**
@@ -317,6 +318,7 @@ export default class State {
    * @param {Vector} offset
    */
   fromText(value, offset) {
+    value = State.paddingText(value);
     var lines = value.split('\n');
     var middle = new Vector(0, Math.round(lines.length / 2));
     for (var j = 0; j < lines.length; j++) {
@@ -335,5 +337,17 @@ export default class State {
         this.drawValue(new Vector(i, j).add(offset).subtract(middle), char);
       }
     }
+  }
+
+  /**
+   * For multi-byte character, padding/unpadding blanks.
+   * @param {string} text
+   * @return {string}
+   */
+  static paddingText(text) {
+    return text.replace(/([^\x01-\x7E\xA1-\xDF])/g, "$1 ");
+  }
+  static unpaddingText(text) {
+    return text.replace(/(([^\x01-\x7E\xA1-\xDF]) )/g, "$2");
   }
 }


### PR DESCRIPTION
ref #61, #85

For multi-byte character,
  input  => add blank
  output => remove blank

Add a "padding" checkbox to Export dialog. Because it is hard to look
when data is passed to ditaa with the content of blank removed.