### PR TITLE
Explicitly use HTTPS to load third-party links

### DIFF
--- a/index.html
+++ b/index.html
@@ -571,7 +571,7 @@ textarea {
 
 <div id="drive-dialog" class="dialog">
   <div id="drive-filename">Untitled ASCII Diagram</div>
-  <div style="margin: 5px;">Edit permissions and manage files in <a href="http://drive.google.com/" target="_blank">Google Drive</a>.</div>
+  <div style="margin: 5px;">Edit permissions and manage files in <a href="https://drive.google.com/" target="_blank">Google Drive</a>.</div>
   <br>
   <button id="drive-new-file-button">New Drawing</button>
   <br>
@@ -599,13 +599,13 @@ if (width > 750) {
   window._tpm['trackPageview'] = true;
 }
 </script>
-<script type="text/javascript" src="//code.tinypass.com/tpl/d1/tpm.js"></script>
+<script type="text/javascript" src="https://code.tinypass.com/tpl/d1/tpm.js"></script>
 
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','analytics');
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','analytics');
 
   analytics('create', 'UA-49427709-1', 'asciiflow.com');
   analytics('send', 'pageview');


### PR DESCRIPTION
While asciiflow.com itself is not HTTPS enabled, using HTTPS for
third-party resouces is still a good thing.