### PR TITLE
Fix second row panels overflowing toolbar width

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,30 +79,34 @@ site/                  # Static site assets
 
 ## Issue Priority List
 
-Triaged February 2025 with help from Claude. See GitHub issues for full details.
+Re-triaged February 2026. See GitHub issues for full details.
 
-### Bugs — Quick Fixes
+### Fixed in staging (merged to main, pending production deploy)
 
 | Issue | Summary |
 |-------|---------|
-| #258 | Blurry canvas on HiDPI/Retina displays (canvas DPI scaling) |
-| #189 | Ctrl+Z triggers browser undo instead of app undo (missing preventDefault) |
-| #202 | Apostrophe/slash in text mode triggers Firefox Quick Find (missing preventDefault) |
+| #258 | Blurry canvas on HiDPI/Retina displays — DPR scaling implemented |
+| #189 | Ctrl+Z triggers browser undo — preventDefault added |
+| #202 | Apostrophe/slash triggers Firefox Quick Find — preventDefault added |
 | #193 | Backspace in text mode doesn't move cursor |
-| #332 | Undo while entering text reverts previous drawing action instead of text |
+| #332 | Undo while entering text reverts previous drawing action |
 | #307 | Delete doesn't work for first scene |
-| #321 | Side-scroll wheel only zooms out (horizontal scroll event handling) |
+| #321 | Side-scroll wheel only zooms out |
+| #28 | Pan/zoom UX — scroll pans, Cmd+scroll zooms |
+| #129 | Two-finger swipe panning |
+| #195 | Space-to-pan in text mode |
+| #297 | Space and Delete in text mode |
+| #187 | Line breaks in paste — line ending normalization |
+| #338 | Copy/paste on macOS Safari/Firefox — native clipboard events |
+| #246 | Visible gridlines — toggle in view panel |
+| #238 | Usability review — closed, bulk addressed by terminal UI overhaul |
 
-### Bugs — Moderate Effort
+### Open bugs
 
 | Issue | Summary |
 |-------|---------|
-| #28 | Pan/zoom UX overhaul: scroll should pan, require modifier for zoom. Trackpad/touchpad issues across platforms |
-| #129 | Two-finger swipe should pan, not zoom (related to #28) |
-| #195 | Space-to-pan conflicts with space-to-insert in text mode |
-| #297 | Space and Delete stop working in text mode in certain states |
-| #187 | Line breaks handled incorrectly when pasting (also #211 — broken spaces in export) |
-| #338 | Copy/paste not working on macOS Tahoe Safari and Firefox |
+| #211 | Spaces broken during export |
+| #85 | CJK character support (fullwidth characters, IME input) |
 
 ### Feature Requests — High Priority
 
@@ -111,9 +115,8 @@ Triaged February 2025 with help from Claude. See GitHub issues for full details.
 | #241 | Customisable line/border/corner styles (Unicode box-drawing variants, rounded corners, ASCII mode, dashed lines) |
 | #43 | Diagonal lines |
 | #54 | Export selected area only |
-| #190 | Mobile device support |
+| #190 | Mobile device support (toolbar is responsive, needs touch gesture work) |
 | #346 | PWA support for offline/installable use (replaces Electron) |
-| #85 | CJK character support (fullwidth characters, IME input) |
 | #339 | Emoji support (wide character rendering) |
 
 ### Feature Requests — Moderate Priority
@@ -140,10 +143,8 @@ Triaged February 2025 with help from Claude. See GitHub issues for full details.
 | #229 | Circle/ellipse support |
 | #134 | Trapezoid/mux shapes |
 | #336 | Colour support |
-| #246 | Visible gridlines |
 | #228 | Block elements (▀▄█░▒▓) in freeform mode |
 | #273 | Pixel-perfect freeform lines |
-| #274 | Auto-hide/show sidebar on hover |
+| #274 | Auto-hide/show toolbar on hover (rethink with new top bar) |
 | #219 | Copy/paste characters in freeform mode |
 | #296 | VS Code extension (community — ASCIIFlow is MIT) |
-| #238 | Usability review (comprehensive feedback, many items tracked elsewhere) |

--- a/client/toolbar.module.css
+++ b/client/toolbar.module.css
@@ -9,7 +9,8 @@
   right: 0;
   z-index: 20;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
   pointer-events: none;
   padding: 0 var(--space-xl);
   box-sizing: border-box;
@@ -21,8 +22,6 @@
   background: var(--color-bg);
   border: var(--border);
   user-select: none;
-  display: inline-flex;
-  flex-direction: column;
   white-space: nowrap;
   pointer-events: auto;
   max-width: 100%;
@@ -42,16 +41,16 @@
 /* --- Secondary row (contextual: file list, help, export, freeform chars) --- */
 
 .secondRow {
-  border-top: var(--border);
+  font-family: var(--font-mono);
+  font-size: var(--font-size);
+  background: var(--color-bg);
+  border: var(--border);
+  border-top: none;
+  margin-top: -1px;
   padding: var(--space-md);
-  display: flex;
-  align-items: flex-start;
-  gap: var(--space-md);
-  flex-wrap: wrap;
   white-space: normal;
-  width: 0;
-  min-width: 100%;
   box-sizing: border-box;
+  pointer-events: auto;
 }
 
 /* --- Branding --- */
@@ -311,47 +310,38 @@
 
 /* --- Help content (inline in second row, table layout) --- */
 
-.helpTable {
-  font-family: var(--font-mono);
-  font-size: var(--font-size);
-  color: var(--color-text);
-  border-collapse: collapse;
-  table-layout: fixed;
-  width: 100%;
+.helpContent {
   line-height: 1.6;
+  color: var(--color-text);
 }
 
-.helpTable td {
-  padding: 0 var(--space-sm);
-  vertical-align: top;
-  word-wrap: break-word;
+.helpGrid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0 var(--space-md);
+}
+
+.helpGrid > span {
   overflow-wrap: break-word;
+  min-width: 0;
 }
 
-.helpTable td:first-child {
+.helpGrid > span:nth-child(odd) {
   white-space: nowrap;
-  padding-right: var(--space-md);
-  width: 1%;
 }
 
 .helpSection {
   color: var(--color-text-muted);
   font-weight: bold;
-  padding: 0 var(--space-sm) !important;
 }
 
 .helpDivider {
-  color: var(--color-border);
-  font-weight: normal;
-  line-height: 1.6;
-  padding: 0 var(--space-sm) !important;
-  overflow: hidden;
-  white-space: nowrap;
+  border-top: 1px solid var(--color-border);
+  margin: var(--space-xs) 0;
 }
 
 .helpExplainer {
   color: var(--color-text-muted);
-  padding: 0 var(--space-sm) !important;
 }
 
 .helpLink {

--- a/client/toolbar.module.css
+++ b/client/toolbar.module.css
@@ -49,7 +49,8 @@
   gap: var(--space-md);
   flex-wrap: wrap;
   white-space: normal;
-  min-width: 0;
+  width: 0;
+  min-width: 100%;
   box-sizing: border-box;
 }
 
@@ -315,9 +316,8 @@
   font-size: var(--font-size);
   color: var(--color-text);
   border-collapse: collapse;
+  table-layout: fixed;
   width: 100%;
-  max-width: 100%;
-  table-layout: auto;
   line-height: 1.6;
 }
 
@@ -331,6 +331,7 @@
 .helpTable td:first-child {
   white-space: nowrap;
   padding-right: var(--space-md);
+  width: 1%;
 }
 
 .helpSection {


### PR DESCRIPTION
Fix: width:0/min-width:100% on secondRow so it contributes zero intrinsic width but stretches to fill the parent. Prevents help/export panels from pushing toolbar wider than the top row.