### PR TITLE
Unify mouse/touch input with Pointer Events

### DIFF
--- a/client/app.tsx
+++ b/client/app.tsx
@@ -3,8 +3,7 @@ import * as React from "react";
 import styles from "#asciiflow/client/app.module.css";
 import {
   Controller,
-  DesktopController,
-  TouchController,
+  InputController,
 } from "#asciiflow/client/controller";
 import { Toolbar } from "#asciiflow/client/toolbar";
 import { DrawingId, store, ToolMode, useAppStore } from "#asciiflow/client/store";
@@ -18,8 +17,7 @@ import { layerToText, textToLayer } from "#asciiflow/client/text_utils";
 import { CHAR_PIXELS_H, CHAR_PIXELS_V } from "#asciiflow/client/constants";
 
 const controller = new Controller();
-const touchController = new TouchController(controller);
-const desktopController = new DesktopController(controller);
+const inputController = new InputController(controller);
 
 export interface IRouteProps {
   local: string;
@@ -43,8 +41,7 @@ export const App = () => {
     <div className={[styles.app, darkMode ? "dark" : ""].join(" ")}>
       <Toolbar />
       <View
-        {...desktopController.getHandlerProps()}
-        {...touchController.getHandlerProps()}
+        {...inputController.getHandlerProps()}
       />
     </div>
   );
@@ -85,7 +82,7 @@ document.getElementById("root").addEventListener("keyup", (e) => controller.hand
 // suppress browser page zoom on Ctrl+scroll / pinch-to-zoom.
 document.getElementById("root").addEventListener(
   "wheel",
-  (e) => desktopController.handleWheel(e),
+  (e) => inputController.handleWheel(e),
   { passive: false }
 );
 

--- a/client/constants.ts
+++ b/client/constants.ts
@@ -113,9 +113,6 @@ export const MAX_UNDO = 50;
 export const SPECIAL_LINE_H = "-";
 export const SPECIAL_LINE_V = "|";
 
-export const DRAG_LATENCY = 150; // Milliseconds.
-export const DRAG_ACCURACY = 6; // Pixels.
-
 // Character cell dimensions — measured dynamically from the loaded font.
 // Re-exported from font.ts so existing `import * as constants` usage keeps working.
 export { CHAR_PIXELS_H, CHAR_PIXELS_V } from "#asciiflow/client/font";

--- a/client/toolbar.tsx
+++ b/client/toolbar.tsx
@@ -85,17 +85,13 @@ export function Toolbar() {
   useEffect(() => {
     const el = topBarRef.current;
     if (!el) return;
-    // Prevent wheel events reaching the canvas pan/zoom handler.
-    const stop = (e: WheelEvent) => e.stopPropagation();
-    el.addEventListener("wheel", stop, { passive: true });
-    // Track the topBar's border-box width so the secondRow can match it.
     const ro = new ResizeObserver((entries) => {
       for (const entry of entries) {
         setTopBarWidth(entry.borderBoxSize?.[0]?.inlineSize ?? entry.contentRect.width);
       }
     });
     ro.observe(el);
-    return () => { el.removeEventListener("wheel", stop); ro.disconnect(); };
+    return () => ro.disconnect();
   }, []);
 
   // The freeform tool shows its picker in the second row when no panel is open

--- a/client/vector.ts
+++ b/client/vector.ts
@@ -17,14 +17,8 @@ export class Vector implements IVector {
 
   constructor(public x: number, public y: number) {}
 
-  // TODO: These shouldn't be here.
-  static fromMouseEvent(event: React.MouseEvent<any>) {
+  static fromPointerEvent(event: React.PointerEvent<any> | PointerEvent) {
     return new Vector(event.clientX, event.clientY);
-  }
-
-  static fromTouchEvent(event: React.TouchEvent<any>, index = 0) {
-    const { pageX, pageY } = event.touches[index];
-    return new Vector(pageX, pageY);
   }
 
   toString() {


### PR DESCRIPTION
## Summary
- Replace separate `DesktopController` + `TouchController` with a single `InputController` using Pointer Events
- Single pointer draws, two fingers pan+pinch-zoom — no more timing-based "long press vs swipe" heuristic
- Fix wheel events on toolbar panels (export preview, help) triggering canvas pan/zoom

Closes #190

## Test plan
- [ ] Desktop: left-click draws, middle-click pans, scroll pans, Cmd/Ctrl+scroll zooms
- [ ] Touch: one finger draws, two-finger swipe pans, pinch zooms
- [ ] Scrolling in export preview panel does not pan/zoom the canvas
- [ ] E2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)