### PR TITLE
Entity-aware select/move tool and smarter snapping

### DIFF
--- a/client/characters.ts
+++ b/client/characters.ts
@@ -133,6 +133,40 @@ export function connections(value: string): Set<Direction> {
   return BOX_DRAWING_INFO[value]?.connections ?? new Set();
 }
 
+// Reverse lookup: the line/junction glyph that connects exactly a given set of
+// directions (used to normalise a cell to match its neighbours). Arrows are
+// excluded; sets of fewer than two directions have no canonical glyph.
+const LINE_GLYPHS = [
+  UNICODE.cornerTopLeft,
+  UNICODE.cornerTopRight,
+  UNICODE.cornerBottomRight,
+  UNICODE.cornerBottomLeft,
+  UNICODE.lineHorizontal,
+  UNICODE.lineVertical,
+  UNICODE.junctionDown,
+  UNICODE.junctionUp,
+  UNICODE.junctionLeft,
+  UNICODE.junctionRight,
+  UNICODE.junctionAll,
+];
+
+function directionKey(dirs: Direction[]): string {
+  return [Direction.UP, Direction.DOWN, Direction.LEFT, Direction.RIGHT]
+    .map((d) => (dirs.indexOf(d) >= 0 ? "1" : "0"))
+    .join("");
+}
+
+const GLYPH_BY_CONNECTIONS = new Map<string, string>(
+  LINE_GLYPHS.map(
+    (glyph) => [directionKey([...connections(glyph)]), glyph] as [string, string]
+  )
+);
+
+/** The glyph connecting exactly `dirs`, or null if there isn't a clean one. */
+export function connectionGlyph(dirs: Direction[]): string | null {
+  return GLYPH_BY_CONNECTIONS.get(directionKey(dirs)) ?? null;
+}
+
 export function connect(
   value: string,
   direction: Direction | Direction[]
@@ -245,6 +279,9 @@ export function disconnect(
     if (value === UNICODE.junctionUp) {
       return UNICODE.junctionDown;
     }
+    if (value === UNICODE.junctionAll) {
+      return UNICODE.junctionUp;
+    }
   }
   if (direction === Direction.LEFT) {
     if (value === UNICODE.junctionLeft) {
@@ -259,6 +296,9 @@ export function disconnect(
     if (value === UNICODE.junctionRight) {
       return UNICODE.junctionLeft;
     }
+    if (value === UNICODE.junctionAll) {
+      return UNICODE.junctionRight;
+    }
   }
   if (direction === Direction.RIGHT) {
     if (value === UNICODE.junctionRight) {
@@ -272,6 +312,9 @@ export function disconnect(
     }
     if (value === UNICODE.junctionLeft) {
       return UNICODE.junctionRight;
+    }
+    if (value === UNICODE.junctionAll) {
+      return UNICODE.junctionLeft;
     }
   }
   // There are a few cases where we just can't do this, and that has to be OK.

--- a/client/draw/box.spec.ts
+++ b/client/draw/box.spec.ts
@@ -1,0 +1,63 @@
+// Must be first import: shims localStorage and window for Node.js.
+import "#asciiflow/testing/test_setup";
+
+import {
+  DrawingId,
+  store,
+  ToolMode,
+  useAppStore,
+} from "#asciiflow/client/store/index";
+import { textToLayer } from "#asciiflow/client/text_utils";
+import { Vector } from "#asciiflow/client/vector";
+import { assert } from "chai";
+
+function reset() {
+  localStorage.clear();
+  useAppStore.setState(
+    {
+      route: DrawingId.local(null),
+      selectedToolMode: ToolMode.BOX,
+      freeformCharacter: "x",
+      altPressed: false,
+      currentCursor: "default",
+      modifierKeys: {},
+      unicode: true,
+      controlsOpen: true,
+      fileControlsOpen: true,
+      editControlsOpen: true,
+      helpControlsOpen: true,
+      exportConfig: {},
+      localDrawingIds: [],
+      darkMode: false,
+      canvasVersion: 0,
+    },
+    true
+  );
+}
+
+describe("DrawBox snapping", () => {
+  beforeEach(reset);
+
+  it("draws a clean box when nothing is adjacent", () => {
+    const tool = store.currentTool; // boxTool
+    tool.start(new Vector(0, 0), {});
+    tool.move(new Vector(2, 2), {});
+    tool.end();
+    const c = store.currentCanvas.committed;
+    assert.equal(c.get(new Vector(0, 0)), "┌");
+    assert.equal(c.get(new Vector(2, 0)), "┐");
+    assert.equal(c.get(new Vector(0, 2)), "└");
+    assert.equal(c.get(new Vector(2, 2)), "┘");
+  });
+
+  it("connects to a line that terminates on an edge", () => {
+    store.currentCanvas.committed = textToLayer("\n──"); // ─ at (0,1),(1,1)
+    const tool = store.currentTool;
+    tool.start(new Vector(2, 0), {});
+    tool.move(new Vector(4, 2), {}); // box (2,0)-(4,2); left edge at x=2
+    tool.end();
+    const c = store.currentCanvas.committed;
+    assert.equal(c.get(new Vector(2, 1)), "┤"); // edge became a junction
+    assert.equal(c.get(new Vector(1, 1)), "─"); // line still there, connected
+  });
+});

--- a/client/draw/box.ts
+++ b/client/draw/box.ts
@@ -2,6 +2,7 @@ import { Box } from "#asciiflow/client/common";
 import { UNICODE } from "#asciiflow/client/constants";
 import { AbstractDrawFunction } from "#asciiflow/client/draw/function";
 import { Layer } from "#asciiflow/client/layer";
+import { snap } from "#asciiflow/client/snap";
 import { store } from "#asciiflow/client/store";
 import { Vector } from "#asciiflow/client/vector";
 
@@ -35,6 +36,10 @@ export class DrawBox extends AbstractDrawFunction {
       layer.set(box.bottomRight(), UNICODE.cornerBottomRight);
       layer.set(box.bottomLeft(), UNICODE.cornerBottomLeft);
     }
+
+    // Connect the box to any adjacent lines/boxes (and tidy the junctions),
+    // the same way the line tool snaps.
+    layer.setFrom(snap(layer, store.currentCanvas.committed));
 
     store.currentCanvas.setScratchLayer(layer);
   }

--- a/client/draw/entity.spec.ts
+++ b/client/draw/entity.spec.ts
@@ -1,0 +1,117 @@
+import {
+  cellsInBox,
+  detectLineTip,
+  detectWord,
+  findBox,
+  moveCells,
+  traceLineFromTip,
+} from "#asciiflow/client/draw/entity";
+import { Layer } from "#asciiflow/client/layer";
+import { layerToText, textToLayer } from "#asciiflow/client/text_utils";
+import { Vector } from "#asciiflow/client/vector";
+import { expect } from "chai";
+
+function fromText(...lines: string[]) {
+  return textToLayer(lines.join("\n"));
+}
+
+function apply(committed: Layer, scratch: Layer) {
+  const [next] = committed.apply(scratch);
+  return next;
+}
+
+describe("entity", () => {
+  describe("detectWord", () => {
+    it("selects a contiguous run of text, stopping at spaces", () => {
+      const layer = fromText("hi there");
+      const word = detectWord(layer, new Vector(4, 0));
+      expect(word?.map((v) => v.toString())).deep.equals([
+        "3:0",
+        "4:0",
+        "5:0",
+        "6:0",
+        "7:0",
+      ]);
+    });
+
+    it("returns null on empty / box-drawing cells", () => {
+      const layer = fromText("┌─┐");
+      expect(detectWord(layer, new Vector(0, 0))).equals(null);
+      expect(detectWord(layer, new Vector(50, 50))).equals(null);
+    });
+
+    it("moves a word", () => {
+      const layer = fromText("hi there");
+      const word = detectWord(layer, new Vector(0, 0)); // "hi"
+      const moved = apply(layer, moveCells(layer, word, new Vector(0, 3)));
+      expect(moved.get(new Vector(0, 0))).equals(null);
+      expect(moved.get(new Vector(0, 3))).equals("h");
+      expect(moved.get(new Vector(1, 3))).equals("i");
+      // "there" untouched.
+      expect(moved.get(new Vector(3, 0))).equals("t");
+    });
+  });
+
+  describe("findBox", () => {
+    const layer = fromText("┌───┐", "│ x │", "└───┘");
+
+    it("finds the box from the interior", () => {
+      const box = findBox(layer, new Vector(3, 1));
+      expect(box?.left()).equals(0);
+      expect(box?.top()).equals(0);
+      expect(box?.right()).equals(4);
+      expect(box?.bottom()).equals(2);
+    });
+
+    it("finds the box from a corner and an edge", () => {
+      for (const p of [new Vector(0, 0), new Vector(2, 0), new Vector(4, 2)]) {
+        const box = findBox(layer, p);
+        expect(box?.left(), `from ${p}`).equals(0);
+        expect(box?.right(), `from ${p}`).equals(4);
+      }
+    });
+
+    it("returns null when there is no enclosing rectangle", () => {
+      expect(findBox(fromText("hello"), new Vector(2, 0))).equals(null);
+      expect(findBox(layer, new Vector(40, 40))).equals(null);
+    });
+
+    it("moves the whole box and its contents", () => {
+      const box = findBox(layer, new Vector(2, 0));
+      const moved = apply(layer, moveCells(layer, cellsInBox(layer, box), new Vector(10, 5)));
+      expect(layerToText(moved)).equals(["┌───┐", "│ x │", "└───┘"].join("\n"));
+      // ...now living at the shifted origin.
+      expect(moved.get(new Vector(10, 5))).equals("┌");
+      expect(moved.get(new Vector(12, 6))).equals("x");
+      expect(moved.get(new Vector(0, 0))).equals(null);
+    });
+  });
+
+  describe("line tips", () => {
+    it("detects an arrow tip and not the middle", () => {
+      const layer = fromText("───►");
+      const tip = detectLineTip(layer, new Vector(3, 0));
+      expect(tip?.axis).equals("horizontal");
+      expect(tip?.arrow).equals("►");
+      expect(detectLineTip(layer, new Vector(1, 0))).equals(null);
+    });
+
+    it("traces a straight line from the tip back to its anchor", () => {
+      const layer = fromText("───►");
+      const tip = detectLineTip(layer, new Vector(3, 0));
+      const { cells, anchor } = traceLineFromTip(layer, tip.tip, tip.bodyDir);
+      expect(anchor.toString()).equals("0:0");
+      expect(cells.length).equals(4); // ► ─ ─ ─
+    });
+
+    it("stops at the first bend (the pivot), keeping the rest of the line", () => {
+      // ► tip at (3,0) → left along the top → first corner ┌ at (0,0); the
+      // vertical leg below it is left alone.
+      const l = fromText("┌──►", "│");
+      const tip = detectLineTip(l, new Vector(3, 0));
+      const { cells, anchor } = traceLineFromTip(l, tip.tip, tip.bodyDir);
+      expect(anchor.toString()).equals("0:0"); // pivot is the first corner
+      expect(cells.length).equals(4); // ► ─ ─ ┌
+    });
+  });
+});

--- a/client/draw/entity.ts
+++ b/client/draw/entity.ts
@@ -1,0 +1,600 @@
+import {
+  connects,
+  connections,
+  isArrow,
+  isBoxDrawing,
+} from "#asciiflow/client/characters";
+import { Box } from "#asciiflow/client/common";
+import { UNICODE } from "#asciiflow/client/constants";
+import { Direction } from "#asciiflow/client/direction";
+import { Layer } from "#asciiflow/client/layer";
+import { snap } from "#asciiflow/client/snap";
+import { Vector } from "#asciiflow/client/vector";
+
+const H = UNICODE.lineHorizontal;
+const V = UNICODE.lineVertical;
+
+/** A cell holds something other than empty/space. */
+export function isContent(value: string) {
+  return value != null && value !== "" && value !== " ";
+}
+
+/** A printable, non-box-drawing character — i.e. label/text content. */
+export function isText(value: string) {
+  return isContent(value) && !isBoxDrawing(value);
+}
+
+// ---------------------------------------------------------------------------
+// Word detection — a maximal horizontal run of text characters.
+// ---------------------------------------------------------------------------
+
+export function detectWord(layer: Layer, position: Vector): Vector[] | null {
+  if (!isText(layer.get(position))) {
+    return null;
+  }
+  let left = position;
+  let right = position;
+  while (isText(layer.get(left.left()))) {
+    left = left.left();
+  }
+  while (isText(layer.get(right.right()))) {
+    right = right.right();
+  }
+  const cells: Vector[] = [];
+  for (let x = left.x; x <= right.x; x++) {
+    cells.push(new Vector(x, position.y));
+  }
+  return cells;
+}
+
+// ---------------------------------------------------------------------------
+// Line-tip detection — the free end of a line/arrow, for extension.
+// ---------------------------------------------------------------------------
+
+export interface LineTip {
+  tip: Vector;
+  axis: "horizontal" | "vertical";
+  /** Direction from the tip toward the rest of the line. */
+  bodyDir: Direction;
+  /** Arrow head character at the tip, if any. */
+  arrow: string | null;
+}
+
+export function detectLineTip(layer: Layer, position: Vector): LineTip | null {
+  const value = layer.get(position);
+  let axis: "horizontal" | "vertical" | null = null;
+  if (value === H) {
+    axis = "horizontal";
+  } else if (value === V) {
+    axis = "vertical";
+  } else if (isArrow(value)) {
+    axis =
+      value === UNICODE.arrowLeft || value === UNICODE.arrowRight
+        ? "horizontal"
+        : "vertical";
+  } else {
+    return null;
+  }
+
+  const dirs =
+    axis === "horizontal"
+      ? [Direction.LEFT, Direction.RIGHT]
+      : [Direction.UP, Direction.DOWN];
+
+  // A tip connects to the line body on exactly one side.
+  const connected = dirs.filter((d) =>
+    connects(layer.get(position.add(d)), d.opposite())
+  );
+  if (connected.length !== 1) {
+    return null;
+  }
+  return {
+    tip: position,
+    axis,
+    bodyDir: connected[0],
+    arrow: isArrow(value) ? value : null,
+  };
+}
+
+/**
+ * Walks a line from its `tip` toward the body and stops at the **first** bend —
+ * the pivot. Returns the cells from the tip up to and including that corner (or
+ * the far end of a straight line), so a tip drag reshapes only the last segment
+ * and "turns" it, leaving the rest of the line untouched.
+ */
+export function traceLineFromTip(
+  layer: Layer,
+  tip: Vector,
+  bodyDir: Direction
+): { cells: Vector[]; anchor: Vector } {
+  const cells: Vector[] = [tip];
+  let current = tip.add(bodyDir);
+  for (let steps = 0; steps < 1000; steps++) {
+    const value = layer.get(current);
+    if (value === straightCharFor(bodyDir)) {
+      cells.push(current);
+      current = current.add(bodyDir);
+      continue;
+    }
+    // First corner → it's the pivot; include it and stop.
+    if (BENDS.has(value) && connects(value, bodyDir.opposite())) {
+      cells.push(current);
+      return { cells, anchor: current };
+    }
+    break; // terminal (junction / arrow / box / empty)
+  }
+  return { cells, anchor: cells[cells.length - 1] };
+}
+
+// ---------------------------------------------------------------------------
+// Box detection — the closed rectangle enclosing a point (border or interior).
+// ---------------------------------------------------------------------------
+
+function isVerticalBorder(value: string) {
+  return (
+    isBoxDrawing(value) &&
+    (connects(value, Direction.UP) || connects(value, Direction.DOWN))
+  );
+}
+
+function isHorizontalBorder(value: string) {
+  return (
+    isBoxDrawing(value) &&
+    (connects(value, Direction.LEFT) || connects(value, Direction.RIGHT))
+  );
+}
+
+const RAY_LIMIT = 400;
+
+function ray(
+  layer: Layer,
+  from: Vector,
+  direction: Direction,
+  predicate: (value: string) => boolean
+): Vector | null {
+  let position = from;
+  for (let i = 0; i < RAY_LIMIT; i++) {
+    position = position.add(direction);
+    if (predicate(layer.get(position))) {
+      return position;
+    }
+  }
+  return null;
+}
+
+function verifyPerimeter(layer: Layer, box: Box): boolean {
+  const left = box.left();
+  const right = box.right();
+  const top = box.top();
+  const bottom = box.bottom();
+  for (let x = left; x <= right; x++) {
+    if (!isBoxDrawing(layer.get(new Vector(x, top)))) return false;
+    if (!isBoxDrawing(layer.get(new Vector(x, bottom)))) return false;
+  }
+  for (let y = top; y <= bottom; y++) {
+    if (!isBoxDrawing(layer.get(new Vector(left, y)))) return false;
+    if (!isBoxDrawing(layer.get(new Vector(right, y)))) return false;
+  }
+  return true;
+}
+
+/** Ray-cast a rectangle from an interior seed cell. */
+function boxFromSeed(layer: Layer, seed: Vector): Box | null {
+  const left = ray(layer, seed, Direction.LEFT, isVerticalBorder);
+  const right = ray(layer, seed, Direction.RIGHT, isVerticalBorder);
+  const up = ray(layer, seed, Direction.UP, isHorizontalBorder);
+  const down = ray(layer, seed, Direction.DOWN, isHorizontalBorder);
+  if (!left || !right || !up || !down) {
+    return null;
+  }
+  const box = new Box(new Vector(left.x, up.y), new Vector(right.x, down.y));
+  // A real box has area.
+  if (box.right() - box.left() < 1 || box.bottom() - box.top() < 1) {
+    return null;
+  }
+  if (!verifyPerimeter(layer, box)) {
+    return null;
+  }
+  return box;
+}
+
+function area(box: Box) {
+  return (box.right() - box.left()) * (box.bottom() - box.top());
+}
+
+const DIAGONALS = [
+  new Vector(-1, -1),
+  new Vector(1, -1),
+  new Vector(-1, 1),
+  new Vector(1, 1),
+];
+
+const COMPONENT_LIMIT = 4000;
+
+/**
+ * The connected component of box-drawing cells reachable from `start` (4-way
+ * adjacency). Returns null if it grows past a sane bound.
+ */
+function borderComponent(layer: Layer, start: Vector): Vector[] | null {
+  const seen = new Set<string>([start.toString()]);
+  const stack = [start];
+  const cells: Vector[] = [];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    cells.push(current);
+    if (cells.length > COMPONENT_LIMIT) {
+      return null;
+    }
+    for (const d of Direction.ALL) {
+      const next = current.add(d);
+      const key = next.toString();
+      if (!seen.has(key) && isBoxDrawing(layer.get(next))) {
+        seen.add(key);
+        stack.push(next);
+      }
+    }
+  }
+  return cells;
+}
+
+/**
+ * Finds the closed box enclosing `position`. Works whether the grabbed cell is
+ * on the border (corner or edge) or in the interior, and for boxes with no
+ * interior (e.g. two rows tall). Returns null if there's no clean rectangle.
+ * When boxes nest, the smallest enclosing one wins.
+ */
+export function findBox(layer: Layer, position: Vector): Box | null {
+  const candidates: Box[] = [];
+
+  // Ray-cast from interior seeds — robust for boxes with an interior, and the
+  // only option when the grabbed cell is inside the box.
+  const seeds: Vector[] = [];
+  if (!isBoxDrawing(layer.get(position))) {
+    seeds.push(position);
+  } else {
+    // On a border cell: seed from any neighbour off the border (a corner's
+    // interior is diagonal, an edge's is orthogonal).
+    for (const d of [...Direction.ALL, ...DIAGONALS]) {
+      const neighbour = position.add(d);
+      if (!isBoxDrawing(layer.get(neighbour))) {
+        seeds.push(neighbour);
+      }
+    }
+  }
+  for (const seed of seeds) {
+    const box = boxFromSeed(layer, seed);
+    if (box && box.contains(position)) {
+      candidates.push(box);
+    }
+  }
+
+  // Trace the connected border — robust for thin boxes with no interior. The
+  // bounding box of an isolated rectangle is the rectangle itself; if lines are
+  // attached the bbox over-grows and the perimeter check rejects it.
+  if (isBoxDrawing(layer.get(position))) {
+    const component = borderComponent(layer, position);
+    const bounds = component && boundingBox(component);
+    if (
+      bounds &&
+      bounds.right() - bounds.left() >= 1 &&
+      bounds.bottom() - bounds.top() >= 1 &&
+      bounds.contains(position) &&
+      verifyPerimeter(layer, bounds)
+    ) {
+      candidates.push(bounds);
+    }
+  }
+
+  let best: Box | null = null;
+  for (const box of candidates) {
+    if (!best || area(box) < area(best)) {
+      best = box;
+    }
+  }
+  return best;
+}
+
+/** All content cells (border + interior text) within a box. */
+export function cellsInBox(layer: Layer, box: Box): Vector[] {
+  return layer
+    .keys()
+    .filter((key) => box.contains(key) && isContent(layer.get(key)));
+}
+
+// ---------------------------------------------------------------------------
+// Generic move — translate a set of cells by a delta, with snapping.
+// ---------------------------------------------------------------------------
+
+export function moveCells(
+  committed: Layer,
+  cells: Vector[],
+  delta: Vector
+): Layer {
+  const layer = new Layer();
+  // Erase originals first.
+  for (const cell of cells) {
+    layer.set(cell, "");
+  }
+  // Then draw the translated content (overwriting erasures where they overlap).
+  const protect = new Set<string>();
+  for (const cell of cells) {
+    const value = committed.get(cell);
+    if (isContent(value)) {
+      const target = cell.add(delta);
+      layer.set(target, value);
+      protect.add(target.toString());
+    }
+  }
+  // Don't re-snap the moved content itself, only the structure around it.
+  layer.setFrom(snap(layer, committed, protect));
+  return layer;
+}
+
+// ---------------------------------------------------------------------------
+// Box move that keeps attached lines connected.
+// ---------------------------------------------------------------------------
+
+export interface BoxAttachment {
+  /** Border cell of the box the line attaches to. */
+  anchor: Vector;
+  /** Outward direction, away from the box. */
+  out: Direction;
+  /** The fixed endpoint the connector must still reach (arrow / junction / other box). */
+  far: Vector;
+  /** All connector cells between the box and `far`, including corners (erased and redrawn). */
+  runCells: Vector[];
+  /** The line ends in an arrow head pointing *into* the box, which rides along on a move. */
+  arrowIntoBox?: boolean;
+}
+
+const BENDS = new Set([
+  UNICODE.cornerTopLeft,
+  UNICODE.cornerTopRight,
+  UNICODE.cornerBottomRight,
+  UNICODE.cornerBottomLeft,
+]);
+
+/** Where a corner turns to, given the direction we arrived travelling. */
+function turnFrom(value: string, dir: Direction): Direction | null {
+  for (const d of connections(value)) {
+    if (d !== dir.opposite()) {
+      return d;
+    }
+  }
+  return null;
+}
+
+function straightCharFor(out: Direction) {
+  return out === Direction.LEFT || out === Direction.RIGHT ? H : V;
+}
+
+/** Perimeter cells of a box paired with their outward direction(s). */
+function perimeter(box: Box): Array<[Vector, Direction]> {
+  const out: Array<[Vector, Direction]> = [];
+  for (let x = box.left(); x <= box.right(); x++) {
+    out.push([new Vector(x, box.top()), Direction.UP]);
+    out.push([new Vector(x, box.bottom()), Direction.DOWN]);
+  }
+  for (let y = box.top(); y <= box.bottom(); y++) {
+    out.push([new Vector(box.left(), y), Direction.LEFT]);
+    out.push([new Vector(box.right(), y), Direction.RIGHT]);
+  }
+  return out;
+}
+
+/**
+ * Finds lines leaving the box and follows each one — through any corners — to
+ * its true terminal (an arrow, another box, a junction, or a free end). The
+ * whole path (including corners) is recorded so it can be redrawn after a move.
+ */
+export function traceBoxAttachments(layer: Layer, box: Box): BoxAttachment[] {
+  const attachments: BoxAttachment[] = [];
+  for (const [anchor, out] of perimeter(box)) {
+    const first = anchor.add(out);
+    const firstValue = layer.get(first);
+
+    // Case A: a straight line leaving the box, pointing back at it.
+    const straightOut =
+      firstValue === straightCharFor(out) &&
+      connects(firstValue, out.opposite());
+    // Case B: an arrow head pointing into the box, with a line behind it.
+    const behind = first.add(out);
+    const arrowIntoBox =
+      firstValue === ARROWS.get(out.opposite()) &&
+      layer.get(behind) === straightCharFor(out) &&
+      connects(layer.get(behind), out.opposite());
+
+    if (!straightOut && !arrowIntoBox) {
+      continue;
+    }
+
+    const runCells: Vector[] = [];
+    let dir = out;
+    // For an arrow attachment, keep the arrow cell and start tracing behind it.
+    let current = first;
+    if (arrowIntoBox) {
+      runCells.push(first);
+      current = behind;
+    }
+    for (let steps = 0; steps < 1000; steps++) {
+      const value = layer.get(current);
+      if (value === straightCharFor(dir)) {
+        runCells.push(current);
+        current = current.add(dir);
+        continue;
+      }
+      // Follow a corner round the bend.
+      if (BENDS.has(value) && connects(value, dir.opposite())) {
+        const next = turnFrom(value, dir);
+        if (!next) {
+          break;
+        }
+        runCells.push(current);
+        dir = next;
+        current = current.add(dir);
+        continue;
+      }
+      break; // terminal: arrow, junction, another box, or empty
+    }
+    attachments.push({ anchor, out, far: current, runCells, arrowIntoBox });
+  }
+  return attachments;
+}
+
+const CORNERS: { [key: string]: string } = {
+  "left,up": UNICODE.cornerBottomRight, // ┘
+  "left,down": UNICODE.cornerTopRight, // ┐
+  "right,up": UNICODE.cornerBottomLeft, // └
+  "right,down": UNICODE.cornerTopLeft, // ┌
+};
+
+function cornerFor(a: Direction, b: Direction) {
+  const horizontal = a === Direction.LEFT || a === Direction.RIGHT ? a : b;
+  const vertical = a === Direction.UP || a === Direction.DOWN ? a : b;
+  const h = horizontal === Direction.LEFT ? "left" : "right";
+  const v = vertical === Direction.UP ? "up" : "down";
+  return CORNERS[`${h},${v}`];
+}
+
+function drawStraight(layer: Layer, from: Vector, to: Vector, excludeEnd: boolean) {
+  const step = new Vector(Math.sign(to.x - from.x), Math.sign(to.y - from.y));
+  const char = step.x !== 0 ? H : V;
+  let p = from;
+  while (true) {
+    if (!(excludeEnd && p.equals(to))) {
+      layer.set(p, char);
+    }
+    if (p.equals(to)) {
+      break;
+    }
+    p = p.add(step);
+  }
+}
+
+const ARROWS = new Map<Direction, string>([
+  [Direction.LEFT, UNICODE.arrowLeft],
+  [Direction.RIGHT, UNICODE.arrowRight],
+  [Direction.UP, UNICODE.arrowUp],
+  [Direction.DOWN, UNICODE.arrowDown],
+]);
+
+/**
+ * Draws an L-shaped connector from `from` (leaving the box) to `to`. `to` is
+ * never overwritten unless it was an arrow head, in which case it's re-pointed
+ * to match the direction the connector now approaches it from.
+ */
+function drawConnector(
+  layer: Layer,
+  from: Vector,
+  to: Vector,
+  out: Direction,
+  farValue: string
+) {
+  if (from.equals(to)) {
+    return;
+  }
+  const horizontalFirst = out === Direction.LEFT || out === Direction.RIGHT;
+  const bend = horizontalFirst
+    ? new Vector(to.x, from.y)
+    : new Vector(from.x, to.y);
+
+  // First leg leaves the box; exclude `bend` if it coincides with the far end.
+  drawStraight(layer, from, bend, bend.equals(to));
+  let approach = out;
+  if (!bend.equals(to)) {
+    drawStraight(layer, bend, to, true);
+    approach = new Vector(
+      Math.sign(to.x - bend.x),
+      Math.sign(to.y - bend.y)
+    ) as Direction;
+  }
+  if (!bend.equals(from) && !bend.equals(to)) {
+    const next = horizontalFirst
+      ? to.y > bend.y
+        ? Direction.DOWN
+        : Direction.UP
+      : to.x > bend.x
+      ? Direction.RIGHT
+      : Direction.LEFT;
+    layer.set(bend, cornerFor(out.opposite(), next));
+  }
+  // Keep an arrow head pointing the way the line now arrives.
+  if (isArrow(farValue)) {
+    for (const [dir, char] of ARROWS) {
+      if (dir.x === approach.x && dir.y === approach.y) {
+        layer.set(to, char);
+      }
+    }
+  }
+}
+
+/**
+ * Moves a box (border + contents) by `delta`, redrawing each attached line so it
+ * stays connected: the far end stays put and the connector reflows (with a bend
+ * when the move isn't parallel to the line).
+ */
+export function moveBoxWithAttachments(
+  committed: Layer,
+  box: Box,
+  attachments: BoxAttachment[],
+  delta: Vector
+): Layer {
+  const layer = new Layer();
+  const content = cellsInBox(committed, box);
+
+  // Erase the box and the old connector runs.
+  for (const cell of content) {
+    layer.set(cell, "");
+  }
+  for (const attachment of attachments) {
+    for (const cell of attachment.runCells) {
+      layer.set(cell, "");
+    }
+  }
+  // Redraw the box at its new home.
+  for (const cell of content) {
+    const value = committed.get(cell);
+    if (isContent(value)) {
+      layer.set(cell.add(delta), value);
+    }
+  }
+  // Reconnect each attachment from the moved edge to its (fixed) far end.
+  for (const attachment of attachments) {
+    const newAnchor = attachment.anchor.add(attachment.out).add(delta);
+    drawConnector(
+      layer,
+      newAnchor,
+      attachment.far,
+      attachment.out,
+      committed.get(attachment.far)
+    );
+    // An arrow that terminates into the box rides along, still pointing in.
+    if (attachment.arrowIntoBox) {
+      layer.set(newAnchor, ARROWS.get(attachment.out.opposite()));
+    }
+  }
+
+  // Protect the moved box's own cells from normalisation — only the connectors
+  // and the structure left behind should be tidied, never the box itself.
+  const protect = new Set(content.map((cell) => cell.add(delta).toString()));
+  layer.setFrom(snap(layer, committed, protect));
+  return layer;
+}
+
+/** Bounding box of an arbitrary set of cells. */
+export function boundingBox(cells: Vector[]): Box | null {
+  if (cells.length === 0) {
+    return null;
+  }
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const cell of cells) {
+    minX = Math.min(minX, cell.x);
+    minY = Math.min(minY, cell.y);
+    maxX = Math.max(maxX, cell.x);
+    maxY = Math.max(maxY, cell.y);
+  }
+  return new Box(new Vector(minX, minY), new Vector(maxX, maxY));
+}

--- a/client/draw/grid.spec.ts
+++ b/client/draw/grid.spec.ts
@@ -1,0 +1,74 @@
+// Must be first import: shims localStorage and window for Node.js.
+import "#asciiflow/testing/test_setup";
+
+import {
+  DrawingId,
+  store,
+  ToolMode,
+  useAppStore,
+} from "#asciiflow/client/store/index";
+import { textToLayer } from "#asciiflow/client/text_utils";
+import { Vector } from "#asciiflow/client/vector";
+import { assert } from "chai";
+
+const tool = store.selectTool;
+
+function reset() {
+  (tool as any).selectedCells = [];
+  (tool as any).selectBox = undefined;
+  (tool as any).activeBox = null;
+  (tool as any).attachments = [];
+  (tool as any).lineReshape = null;
+  (tool as any).dragStart = null;
+  (tool as any).selecting = false;
+  localStorage.clear();
+  useAppStore.setState(
+    {
+      route: DrawingId.local(null),
+      selectedToolMode: ToolMode.SELECT,
+      freeformCharacter: "x",
+      altPressed: false,
+      currentCursor: "default",
+      modifierKeys: {},
+      unicode: true,
+      controlsOpen: true,
+      fileControlsOpen: true,
+      editControlsOpen: true,
+      helpControlsOpen: true,
+      exportConfig: {},
+      localDrawingIds: [],
+      darkMode: false,
+      canvasVersion: 0,
+    },
+    true
+  );
+}
+
+describe("2x2 grid move", () => {
+  beforeEach(reset);
+
+  it("reflows the shared walls so a moved quadrant stays connected", () => {
+    store.currentCanvas.committed = textToLayer(
+      [
+        "┌──┬──┐",
+        "│  │  │",
+        "├──┼──┤",
+        "│  │  │",
+        "└──┴──┘",
+      ].join("\n")
+    );
+    tool.start(new Vector(1, 3), {}); // bottom-left quadrant interior
+    tool.move(new Vector(1, 6), {}); // move the divider down 3
+    tool.end();
+    const c = store.currentCanvas.committed;
+    // The shared walls followed, and every junction is clean after snapping:
+    // the divider now sits at row 5 with proper ├ ┼ ┤ junctions...
+    assert.equal(c.get(new Vector(0, 5)), "├");
+    assert.equal(c.get(new Vector(3, 5)), "┼");
+    assert.equal(c.get(new Vector(6, 5)), "┤");
+    // ...the top-middle junction is untouched...
+    assert.equal(c.get(new Vector(3, 0)), "┬");
+    // ...and the old divider-right simplified to a plain wall (its arm moved).
+    assert.equal(c.get(new Vector(6, 2)), "│");
+  });
+});

--- a/client/draw/line.spec.ts
+++ b/client/draw/line.spec.ts
@@ -1,0 +1,58 @@
+// Must be first import: shims localStorage and window for Node.js.
+import "#asciiflow/testing/test_setup";
+
+import {
+  DrawingId,
+  store,
+  ToolMode,
+  useAppStore,
+} from "#asciiflow/client/store/index";
+import { textToLayer } from "#asciiflow/client/text_utils";
+import { Vector } from "#asciiflow/client/vector";
+import { assert } from "chai";
+
+function reset() {
+  localStorage.clear();
+  useAppStore.setState(
+    {
+      route: DrawingId.local(null),
+      selectedToolMode: ToolMode.LINES,
+      freeformCharacter: "x",
+      altPressed: false,
+      currentCursor: "default",
+      modifierKeys: {},
+      unicode: true,
+      controlsOpen: true,
+      fileControlsOpen: true,
+      editControlsOpen: true,
+      helpControlsOpen: true,
+      exportConfig: {},
+      localDrawingIds: [],
+      darkMode: false,
+      canvasVersion: 0,
+    },
+    true
+  );
+}
+
+describe("DrawLine onto an existing line", () => {
+  beforeEach(reset);
+
+  it("forms a T when a vertical line ends on a horizontal line", () => {
+    store.currentCanvas.committed = textToLayer("───"); // (0..2, 0)
+    const tool = store.currentTool; // lineTool
+    tool.start(new Vector(1, -2), {});
+    tool.move(new Vector(1, 0), {}); // draw down onto the middle
+    tool.end();
+    assert.equal(store.currentCanvas.committed.get(new Vector(1, 0)), "┴");
+  });
+
+  it("forms a T when a horizontal line ends on a vertical line", () => {
+    store.currentCanvas.committed = textToLayer(["│", "│", "│"].join("\n")); // (0, 0..2)
+    const tool = store.currentTool;
+    tool.start(new Vector(-2, 1), {});
+    tool.move(new Vector(0, 1), {}); // draw right onto the middle
+    tool.end();
+    assert.equal(store.currentCanvas.committed.get(new Vector(0, 1)), "┤");
+  });
+});

--- a/client/draw/select.spec.ts
+++ b/client/draw/select.spec.ts
@@ -1,0 +1,255 @@
+// Must be first import: shims localStorage and window for Node.js.
+import "#asciiflow/testing/test_setup";
+
+import {
+  DrawingId,
+  store,
+  ToolMode,
+  useAppStore,
+} from "#asciiflow/client/store/index";
+import { layerToText, textToLayer } from "#asciiflow/client/text_utils";
+import { Vector } from "#asciiflow/client/vector";
+import { assert } from "chai";
+
+// Use the singleton tool via the store facade to avoid the store<->select
+// circular import (which trips a TDZ error when select.ts is the entry module).
+const tool = store.selectTool;
+
+function reset() {
+  // Clear any selection left over from a previous test.
+  (tool as any).selectedCells = [];
+  (tool as any).selectBox = undefined;
+  (tool as any).dragStart = null;
+  (tool as any).lineTip = null;
+  (tool as any).moveTool = null;
+  (tool as any).selecting = false;
+  (tool as any).activeBox = null;
+  (tool as any).attachments = [];
+  localStorage.clear();
+  useAppStore.setState(
+    {
+      route: DrawingId.local(null),
+      selectedToolMode: ToolMode.SELECT,
+      freeformCharacter: "x",
+      altPressed: false,
+      currentCursor: "default",
+      modifierKeys: {},
+      unicode: true,
+      controlsOpen: true,
+      fileControlsOpen: true,
+      editControlsOpen: true,
+      helpControlsOpen: true,
+      exportConfig: {},
+      localDrawingIds: [],
+      darkMode: false,
+      canvasVersion: 0,
+    },
+    true
+  );
+}
+
+function setCommitted(...lines: string[]) {
+  store.currentCanvas.committed = textToLayer(lines.join("\n"));
+}
+
+function text() {
+  return layerToText(store.currentCanvas.committed);
+}
+
+describe("DrawSelect", () => {
+  beforeEach(reset);
+
+  it("moves a whole box (and contents) by dragging its interior", () => {
+    setCommitted("┌───┐", "│ x │", "└───┘");
+    tool.start(new Vector(3, 1), {}); // empty interior cell (not the label)
+    tool.move(new Vector(13, 6)); // drag by (10, 5)
+    tool.end();
+    assert.equal(text(), ["┌───┐", "│ x │", "└───┘"].join("\n"));
+    assert.equal(store.currentCanvas.committed.get(new Vector(10, 5)), "┌");
+    assert.equal(store.currentCanvas.committed.get(new Vector(12, 6)), "x");
+    assert.isNull(store.currentCanvas.committed.get(new Vector(0, 0)));
+  });
+
+  it("resizes a box edge (not move) when grabbing the border", () => {
+    setCommitted("┌───┐", "│   │", "└───┘");
+    tool.start(new Vector(2, 0), {}); // top edge
+    tool.move(new Vector(2, 1)); // pull the top edge down one row
+    tool.end();
+    const committed = store.currentCanvas.committed;
+    // Top edge moved down; bottom edge stayed put → it resized, not translated.
+    assert.isNull(committed.get(new Vector(0, 0)));
+    assert.equal(committed.get(new Vector(0, 1)), "┌");
+    assert.equal(committed.get(new Vector(0, 2)), "└");
+  });
+
+  it("moves a word, leaving the rest of the line", () => {
+    setCommitted("hi there");
+    tool.start(new Vector(0, 0), {}); // "hi"
+    tool.move(new Vector(0, 2)); // down 2
+    tool.end();
+    const committed = store.currentCanvas.committed;
+    assert.equal(committed.get(new Vector(0, 2)), "h");
+    assert.equal(committed.get(new Vector(1, 2)), "i");
+    assert.equal(committed.get(new Vector(3, 0)), "t"); // "there" stayed
+    assert.isNull(committed.get(new Vector(0, 0)));
+  });
+
+  it("extends a line tip outward", () => {
+    setCommitted("───►");
+    tool.start(new Vector(3, 0), {}); // the arrow tip
+    tool.move(new Vector(6, 0));
+    tool.end();
+    const committed = store.currentCanvas.committed;
+    assert.equal(committed.get(new Vector(6, 0)), "►");
+    assert.equal(committed.get(new Vector(5, 0)), "─");
+  });
+
+  it("keeps an attached line connected, shortening it on a parallel move", () => {
+    setCommitted("┌─┐", "│ ├──►", "└─┘");
+    tool.start(new Vector(1, 1), {}); // box interior
+    tool.move(new Vector(2, 1)); // move right by 1
+    tool.end();
+    const c = store.currentCanvas.committed;
+    assert.equal(c.get(new Vector(1, 0)), "┌"); // box moved right
+    assert.equal(c.get(new Vector(3, 1)), "├"); // junction moved with it
+    assert.equal(c.get(new Vector(4, 1)), "─"); // run shortened to one cell
+    assert.equal(c.get(new Vector(5, 1)), "►"); // arrow still there, still pointing right
+  });
+
+  it("reflows an attached line with a bend on a perpendicular move", () => {
+    setCommitted("┌─┐", "│ ├──►", "└─┘");
+    tool.start(new Vector(1, 1), {}); // box interior
+    tool.move(new Vector(1, 2)); // move down by 1
+    tool.end();
+    const c = store.currentCanvas.committed;
+    assert.equal(c.get(new Vector(0, 1)), "┌"); // box moved down
+    assert.equal(c.get(new Vector(3, 2)), "─"); // line leaves the moved edge
+    assert.equal(c.get(new Vector(5, 2)), "┘"); // bends up toward the arrow
+    assert.equal(c.get(new Vector(5, 1)), "▲"); // arrow re-pointed to match approach
+  });
+
+  it("draws a corner when a tip is dragged out of the line's plane", () => {
+    setCommitted("───►");
+    tool.start(new Vector(3, 0), {}); // arrow tip (horizontal line)
+    tool.move(new Vector(3, 3), {}); // drag straight down
+    tool.end();
+    const c = store.currentCanvas.committed;
+    // Leaves the pivot horizontally (its existing axis), then bends down.
+    assert.equal(c.get(new Vector(0, 0)), "─"); // horizontal leg kept
+    assert.equal(c.get(new Vector(3, 0)), "┐"); // corner where it turns down
+    assert.equal(c.get(new Vector(3, 1)), "│"); // vertical leg
+    assert.equal(c.get(new Vector(3, 3)), "▼"); // arrow now points down
+  });
+
+  it("turns only the last segment at the first bend, keeping the rest", () => {
+    // Vertical leg down to a corner, then right to the arrow tip.
+    setCommitted("│", "│", "└──►");
+    tool.start(new Vector(3, 2), {}); // arrow tip (horizontal last segment)
+    tool.move(new Vector(3, 4), {}); // pull it down
+    tool.end();
+    const c = store.currentCanvas.committed;
+    assert.equal(c.get(new Vector(0, 0)), "│"); // kept leg untouched
+    assert.equal(c.get(new Vector(0, 1)), "│"); // kept leg untouched
+    assert.equal(c.get(new Vector(0, 2)), "└"); // pivot corner kept
+    assert.equal(c.get(new Vector(3, 2)), "┐"); // last segment turns down here
+    assert.equal(c.get(new Vector(3, 4)), "▼"); // arrow at the new tip
+  });
+
+  it("traces a connector through its corner and reflows the whole path", () => {
+    setCommitted(
+      "┌─┐",
+      "│ ├─┐",
+      "└─┘ │",
+      "    ▼"
+    );
+    tool.start(new Vector(1, 1), {}); // box interior
+    tool.move(new Vector(1, 2)); // move down by 1
+    tool.end();
+    const c = store.currentCanvas.committed;
+    assert.equal(c.get(new Vector(0, 1)), "┌"); // box moved down
+    assert.isNull(c.get(new Vector(4, 1))); // old corner erased
+    assert.equal(c.get(new Vector(3, 2)), "─"); // reflowed run
+    assert.equal(c.get(new Vector(4, 2)), "┐"); // corner redrawn lower
+    assert.equal(c.get(new Vector(4, 3)), "▼"); // far arrow stays put
+  });
+
+  it("moves the selection through undo/redo with its content", () => {
+    setCommitted("┌─┐", "│ │", "└─┘");
+    tool.start(new Vector(1, 1), {}); // select interior
+    tool.move(new Vector(1, 4), {}); // move down 3
+    tool.end();
+    assert.equal(store.currentCanvas.selection.top(), 3); // at moved position
+    store.currentCanvas.undo();
+    assert.equal(store.currentCanvas.selection.top(), 0); // restored to original
+    store.currentCanvas.redo();
+    assert.equal(store.currentCanvas.selection.top(), 3); // and back again
+  });
+
+  it("purges the selection when switching off the select tool", () => {
+    setCommitted("┌─┐", "│ │", "└─┘");
+    tool.start(new Vector(1, 1), {});
+    tool.end();
+    assert.exists(store.currentCanvas.selection);
+    tool.cleanup();
+    assert.notExists(store.currentCanvas.selection);
+  });
+
+  it("reflows a line crossing the selection edge on a rubber-band move", () => {
+    setCommitted("───►");
+    // Rubber-band the left cells: start on empty, drag across them.
+    tool.start(new Vector(1, 1), {}); // empty, below the line
+    tool.move(new Vector(0, 0), {}); // selection box (0,0)-(1,1)
+    tool.end();
+    // Drag the selection down by one.
+    tool.start(new Vector(0, 0), {}); // inside the selection
+    tool.move(new Vector(0, 1), {});
+    tool.end();
+    const c = store.currentCanvas.committed;
+    assert.equal(c.get(new Vector(0, 1)), "─"); // selected run moved down
+    assert.isNull(c.get(new Vector(0, 0))); // old position cleared
+    assert.equal(c.get(new Vector(3, 1)), "┘"); // line reflowed with a bend
+    assert.equal(c.get(new Vector(3, 0)), "▲"); // arrow stayed put, re-pointed
+  });
+
+  it("keeps an arrow pointing into a box attached when the box moves", () => {
+    setCommitted("   ┌─┐", " ─►│ │", "   └─┘");
+    tool.start(new Vector(4, 1), {}); // box interior
+    tool.move(new Vector(4, 3), {}); // move down 2
+    tool.end();
+    const c = store.currentCanvas.committed;
+    assert.equal(c.get(new Vector(3, 2)), "┌"); // box moved down 2
+    assert.equal(c.get(new Vector(2, 3)), "►"); // arrow rode along, still pointing in
+    assert.isNull(c.get(new Vector(2, 1))); // old arrow position cleared
+  });
+
+  it("keeps a line attached at a box corner connected when the box moves", () => {
+    setCommitted("┌─┬──►", "│ │", "└─┘");
+    tool.start(new Vector(1, 1), {}); // box interior
+    tool.move(new Vector(1, 4), {}); // move down 3
+    tool.end();
+    const c = store.currentCanvas.committed;
+    assert.equal(c.get(new Vector(0, 3)), "┌"); // box moved down 3
+    assert.equal(c.get(new Vector(2, 3)), "┬"); // corner keeps its branch
+    assert.equal(c.get(new Vector(3, 3)), "─"); // line follows out of the corner
+    assert.isNull(c.get(new Vector(3, 0))); // old line cleared
+  });
+
+  it("shift-clicking adds a second box to the selection and moves both", () => {
+    setCommitted(
+      "┌─┐ ┌─┐",
+      "│ │ │ │",
+      "└─┘ └─┘"
+    );
+    tool.start(new Vector(1, 1), {}); // first box interior, begins a drag
+    tool.end(); // ...released without moving — first box selected
+    tool.start(new Vector(5, 1), { shift: true }); // add second box's interior
+    tool.start(new Vector(1, 1), {}); // grab inside selection
+    tool.move(new Vector(1, 6)); // move everything down 5
+    tool.end();
+    const committed = store.currentCanvas.committed;
+    // Both boxes moved down by 5 rows.
+    assert.equal(committed.get(new Vector(0, 5)), "┌");
+    assert.equal(committed.get(new Vector(4, 5)), "┌");
+    assert.isNull(committed.get(new Vector(0, 0)));
+  });
+});

--- a/client/draw/select.ts
+++ b/client/draw/select.ts
@@ -1,171 +1,440 @@
-import { Box } from "#asciiflow/client/common";
 import {
-  isSpecial,
-  KEY_BACKSPACE,
-  KEY_DELETE,
-} from "#asciiflow/client/constants";
+  connect,
+  connectable,
+  connects,
+  disconnect,
+  isBoxDrawing,
+} from "#asciiflow/client/characters";
+import { Box } from "#asciiflow/client/common";
+import { KEY_BACKSPACE, KEY_DELETE, UNICODE } from "#asciiflow/client/constants";
+import { Direction } from "#asciiflow/client/direction";
+import {
+  boundingBox,
+  BoxAttachment,
+  cellsInBox,
+  detectLineTip,
+  detectWord,
+  findBox,
+  moveBoxWithAttachments,
+  moveCells,
+  traceBoxAttachments,
+  traceLineFromTip,
+} from "#asciiflow/client/draw/entity";
 import { AbstractDrawFunction } from "#asciiflow/client/draw/function";
 import { DrawMove } from "#asciiflow/client/draw/move";
-import { Layer } from "#asciiflow/client/layer";
+import { line } from "#asciiflow/client/draw/utils";
+import { Layer, LayerView } from "#asciiflow/client/layer";
 import { snap } from "#asciiflow/client/snap";
 import { IModifierKeys, store } from "#asciiflow/client/store";
 import { Vector } from "#asciiflow/client/vector";
 
+/**
+ * Entity-aware selection / move tool.
+ *
+ * Grab rules (no modifier):
+ *  - a box's empty interior   → move the whole box and its contents; attached
+ *                               lines stay connected and reflow
+ *  - a box border / line      → resize / move that line (DrawMove), as before
+ *  - a free line tip          → extend / retract the line along its axis
+ *  - a word (run of text)     → move the word
+ *  - empty space              → rubber-band select
+ *
+ *  - shift-click an entity    → add it to the current selection (multi-select)
+ */
 export class DrawSelect extends AbstractDrawFunction {
-  private moveTool: DrawMove;
-
+  /** Bounding box of the current selection — kept for the view and copy/paste. */
   public selectBox: Box;
 
+  /** Exact cells making up the current selection (what actually moves). */
+  private selectedCells: Vector[] = [];
+
+  // Rubber-band selection.
+  private selecting = false;
+  private selectAnchor: Vector;
+
+  // Active move drag.
   private dragStart: Vector;
   private dragEnd: Vector;
 
-  constructor() {
-    super();
-  }
+  // Sub-tools / sub-modes.
+  private moveTool: DrawMove;
+
+  // Dragging a line tip: reshape the line like the line tool (free 2D + corners).
+  private lineReshape: {
+    cells: Vector[];
+    anchor: Vector;
+    isArrow: boolean;
+    horizontalSegment: boolean;
+    moved: boolean;
+  };
+
+  // When the selection is a single box, we move it with line reflow.
+  private activeBox: Box;
+  private attachments: BoxAttachment[] = [];
 
   start(position: Vector, modifierKeys: IModifierKeys) {
+    const committed = store.currentCanvas.committed;
+    const value = committed.get(position);
+
+    // Drag the existing selection if grabbing inside it.
     if (
-      this.selectBox != null &&
-      this.selectBox.contains(position) &&
-      !modifierKeys.shift
+      !modifierKeys.shift &&
+      this.selectedCells.length > 0 &&
+      this.inSelection(position)
     ) {
-      // Start a drag.
-      this.startDrag(position);
-    } else if (
-      isSpecial(store.currentCanvas.committed.get(position)) &&
-      !modifierKeys.shift
-    ) {
-      // Start a resize.
+      this.beginDrag(position);
+      return;
+    }
+
+    // Shift: add an entity to the selection, or start a rubber-band.
+    if (modifierKeys.shift) {
+      const cells = this.entityAt(committed, position);
+      if (cells) {
+        this.addToSelection(cells);
+      } else {
+        this.startSelect(position);
+      }
+      return;
+    }
+
+    // Free line tip → reshape the line from its anchor (like the line tool).
+    const tip = detectLineTip(committed, position);
+    if (tip) {
+      const { cells, anchor } = traceLineFromTip(
+        committed,
+        tip.tip,
+        tip.bodyDir
+      );
+      this.lineReshape = {
+        cells,
+        anchor,
+        isArrow: tip.arrow != null,
+        horizontalSegment: tip.axis === "horizontal",
+        moved: false,
+      };
+      return;
+    }
+
+    // Word (text) → move it.
+    const word = detectWord(committed, position);
+    if (word) {
+      this.setSelection(word);
+      this.beginDrag(position);
+      return;
+    }
+
+    // Box-drawing char (a box border or a free line/connector) → resize /
+    // move that line, exactly as before. Box edges stay resizable.
+    if (isBoxDrawing(value)) {
       this.moveTool = new DrawMove();
       this.moveTool.start(position);
-    } else {
-      // Start a selection.
-      this.startSelect(position);
+      return;
     }
+
+    // Empty interior of a box → move the whole box and its contents.
+    const box = findBox(committed, position);
+    if (box) {
+      this.setSelection(cellsInBox(committed, box));
+      this.activeBox = box;
+      this.beginDrag(position);
+      return;
+    }
+
+    // Empty space → rubber-band select.
+    this.startSelect(position);
   }
 
-  startSelect(position: Vector) {
-    this.selectBox = new Box(position, position);
-    store.currentCanvas.setSelection(this.selectBox);
-  }
-
-  startDrag(position: Vector) {
-    this.dragStart = position;
-    this.dragEnd = position;
-  }
-
-  move(position: Vector) {
-    if (this.dragStart != null) {
+  move(position: Vector, modifierKeys: IModifierKeys = {}) {
+    if (this.lineReshape != null) {
+      this.reshapeTip(position, modifierKeys);
+    } else if (this.dragStart != null) {
       this.moveDrag(position);
-    } else if (!!this.moveTool) {
+    } else if (this.moveTool != null) {
       this.moveTool.move(position);
-    } else {
+    } else if (this.selecting) {
       this.moveSelect(position);
     }
   }
 
-  moveSelect(position: Vector) {
-    this.selectBox = new Box(this.selectBox.start, position);
-
-    const selectionLayer = new Layer();
-
-    store.currentCanvas.committed.entries().forEach(([key, value]) => {
-      if (this.selectBox.contains(key)) {
-        selectionLayer.set(key, value);
-      }
-    });
-
-    store.currentCanvas.setScratchLayer(selectionLayer);
-    store.currentCanvas.setSelection(this.selectBox);
-  }
-
-  moveDrag(position: Vector) {
-    this.dragEnd = position;
-    const moveDelta = this.dragEnd.subtract(this.dragStart);
-    store.currentCanvas.setSelection(
-      new Box(
-        this.selectBox.topLeft().add(moveDelta),
-        this.selectBox.bottomRight().add(moveDelta)
-      )
-    );
-
-    const layer = new Layer();
-
-    // Erase existing drawing.
-    store.currentCanvas.committed.entries().forEach(([key]) => {
-      if (this.selectBox.contains(key)) {
-        layer.set(key, "");
-      }
-    });
-    // Move characters.
-    store.currentCanvas.committed.entries().forEach(([key, value]) => {
-      if (this.selectBox.contains(key)) {
-        layer.set(key.add(moveDelta), value);
-      }
-    });
-
-    layer.setFrom(snap(layer, store.currentCanvas.committed));
-
-    store.currentCanvas.setScratchLayer(layer);
-  }
-
   end() {
-    if (this.dragStart != null) {
+    if (this.lineReshape != null) {
+      if (this.lineReshape.moved) {
+        store.currentCanvas.commitScratch();
+      } else {
+        store.currentCanvas.clearScratch();
+      }
+      this.lineReshape = null;
+    } else if (this.dragStart != null) {
+      const delta = this.dragEnd.subtract(this.dragStart);
+      const box = this.activeBox;
       store.currentCanvas.commitScratch();
-      this.selectBox = new Box(
-        this.selectBox.topLeft().add(this.dragEnd).subtract(this.dragStart),
-        this.selectBox.bottomRight().add(this.dragEnd).subtract(this.dragStart)
-      );
-      store.currentCanvas.setSelection(this.selectBox);
-    } else if (!!this.moveTool) {
+      // Follow the content to its new home so it stays selected.
+      if (box) {
+        const moved = new Box(
+          box.topLeft().add(delta),
+          box.bottomRight().add(delta)
+        );
+        // Keep the whole rectangle highlighted (its content may not fill it),
+        // and keep the cell list for cut/copy. Stay an active box for re-drags.
+        this.selectedCells = cellsInBox(store.currentCanvas.committed, moved);
+        this.selectBox = moved;
+        this.activeBox = moved;
+        store.currentCanvas.setSelection(moved);
+      } else {
+        this.setSelection(
+          this.selectedCells.map((cell) => cell.add(delta)),
+          /* keepScratch */ true
+        );
+      }
+    } else if (this.moveTool != null) {
       this.moveTool.end();
       this.moveTool = null;
+    } else if (this.selecting) {
+      this.finishSelect();
     }
     this.dragStart = null;
     this.dragEnd = null;
+    this.selecting = false;
   }
 
-  getCursor(position: Vector) {
-    if (this.selectBox != null && this.selectBox.contains(position)) {
-      return "pointer";
+  // -- selection helpers ----------------------------------------------------
+
+  /** Resolve the entity under a position into a set of cells, if any. */
+  private entityAt(committed: Layer, position: Vector): Vector[] | null {
+    const word = detectWord(committed, position);
+    if (word) {
+      return word;
     }
-    if (isSpecial(store.currentCanvas.committed.get(position))) {
+    const box = findBox(committed, position);
+    if (box) {
+      return cellsInBox(committed, box);
+    }
+    return null;
+  }
+
+  private setSelection(cells: Vector[], keepScratch = false) {
+    this.selectedCells = dedupe(cells);
+    this.selectBox = boundingBox(this.selectedCells);
+    // Any selection that isn't an explicit single box falls back to block move.
+    this.activeBox = null;
+    if (!keepScratch) {
+      store.currentCanvas.clearScratch();
+    }
+    store.currentCanvas.setSelection(this.selectBox);
+  }
+
+  private addToSelection(cells: Vector[]) {
+    this.setSelection([...this.selectedCells, ...cells]);
+  }
+
+  private inSelection(position: Vector) {
+    // Only when a selection is actually live (it gets cleared on undo/redo).
+    return (
+      this.selectBox != null &&
+      store.currentCanvas.selection != null &&
+      this.selectBox.contains(position)
+    );
+  }
+
+  private startSelect(position: Vector) {
+    this.selecting = true;
+    this.selectAnchor = position;
+    this.selectBox = new Box(position, position);
+    this.selectedCells = [];
+    this.activeBox = null;
+    store.currentCanvas.setSelection(this.selectBox);
+  }
+
+  private moveSelect(position: Vector) {
+    this.selectBox = new Box(this.selectAnchor, position);
+    store.currentCanvas.setSelection(this.selectBox);
+  }
+
+  private finishSelect() {
+    this.selectedCells = cellsInBox(
+      store.currentCanvas.committed,
+      this.selectBox
+    );
+    // Treat the selection rectangle like a box: moving it reflows any lines
+    // that cross its edge, and keeps the whole rectangle highlighted.
+    this.activeBox = this.selectBox;
+  }
+
+  // -- move drag ------------------------------------------------------------
+
+  private beginDrag(position: Vector) {
+    this.dragStart = position;
+    this.dragEnd = position;
+    this.attachments = this.activeBox
+      ? traceBoxAttachments(store.currentCanvas.committed, this.activeBox)
+      : [];
+  }
+
+  private moveDrag(position: Vector) {
+    this.dragEnd = position;
+    const delta = this.dragEnd.subtract(this.dragStart);
+    const committed = store.currentCanvas.committed;
+    if (this.activeBox) {
+      store.currentCanvas.setScratchLayer(
+        moveBoxWithAttachments(committed, this.activeBox, this.attachments, delta)
+      );
+      store.currentCanvas.setSelection(
+        new Box(
+          this.activeBox.topLeft().add(delta),
+          this.activeBox.bottomRight().add(delta)
+        )
+      );
+    } else {
+      store.currentCanvas.setScratchLayer(
+        moveCells(committed, this.selectedCells, delta)
+      );
+      store.currentCanvas.setSelection(
+        boundingBox(this.selectedCells.map((cell) => cell.add(delta)))
+      );
+    }
+  }
+
+  // -- line tip reshape -----------------------------------------------------
+
+  private reshapeTip(target: Vector, modifierKeys: IModifierKeys) {
+    this.lineReshape.moved = true;
+    const { cells, anchor, isArrow, horizontalSegment } = this.lineReshape;
+    const committed = store.currentCanvas.committed;
+
+    // A view of the canvas with the old line removed, so reconnection and
+    // snapping don't latch onto the cells we're about to erase.
+    const base = new Layer();
+    base.map = new Map(committed.map);
+    for (const cell of cells) {
+      base.map.delete(cell.toString());
+    }
+
+    const layer = new Layer();
+    for (const cell of cells) {
+      layer.set(cell, "");
+    }
+
+    if (!anchor.equals(target)) {
+      // Leave the pivot along the line's existing axis, then bend toward the
+      // cursor — Alt/Ctrl/Shift flips it. This matches what you expect when
+      // "turning" a line, rather than the generic line-tool heuristic.
+      const flip = Boolean(modifierKeys.ctrl || modifierKeys.shift);
+      const horizontalFirst = horizontalSegment !== flip;
+
+      layer.setFrom(line(anchor, target, horizontalFirst));
+      if (isArrow) {
+        layer.set(target, arrowFor(anchor, target, horizontalFirst));
+      }
+
+      // Connect the endpoints to their neighbours, then trim stray connections.
+      const combined = new LayerView([base, layer]);
+      const ends = isArrow ? [anchor] : [anchor, target];
+      for (const pos of ends) {
+        const incoming = Direction.ALL.filter(
+          (d) =>
+            connects(combined.get(pos.add(d)), d.opposite()) &&
+            connectable(layer.get(pos), d)
+        );
+        layer.set(pos, connect(layer.get(pos), incoming));
+        layer.set(
+          pos,
+          disconnect(
+            layer.get(pos),
+            Direction.ALL.filter((d) => !incoming.includes(d))
+          )
+        );
+      }
+    }
+
+    layer.setFrom(snap(layer, base));
+    store.currentCanvas.setScratchLayer(layer);
+    store.currentCanvas.clearSelection();
+  }
+
+  // -- cursor ---------------------------------------------------------------
+
+  getCursor(position: Vector, modifierKeys: IModifierKeys) {
+    const committed = store.currentCanvas.committed;
+    if (this.selectedCells.length > 0 && this.inSelection(position)) {
+      return "move";
+    }
+    const value = committed.get(position);
+    if (detectLineTip(committed, position)) {
+      return "crosshair";
+    }
+    if (detectWord(committed, position)) {
+      return "move";
+    }
+    // Box border / line → resize cursor; empty interior of a box → move.
+    if (isBoxDrawing(value)) {
+      return new DrawMove().getCursor(position);
+    }
+    if (findBox(committed, position)) {
       return "move";
     }
     return "default";
   }
 
-  /**
-   * Erases the selected content (called from native cut event in app.tsx).
-   */
+  // -- clipboard / keyboard (used by app.tsx) -------------------------------
+
+  /** Erases the selected content (called from the native cut event). */
   cutSelection() {
-    if (this.selectBox == null) return;
+    if (this.selectedCells.length === 0) {
+      return;
+    }
     const layer = new Layer();
-    store.currentCanvas.committed.entries().forEach(([key]) => {
-      if (this.selectBox.contains(key)) {
-        layer.set(key, "");
-      }
-    });
-
+    for (const cell of this.selectedCells) {
+      layer.set(cell, "");
+    }
     layer.setFrom(snap(layer, store.currentCanvas.committed));
-
     store.currentCanvas.setScratchLayer(layer);
     store.currentCanvas.commitScratch();
   }
 
-  handleKey(value: string, modifierKeys: IModifierKeys) {
+  handleKey(value: string) {
     if (value === KEY_BACKSPACE || value === KEY_DELETE) {
-      const layer = new Layer();
-      store.currentCanvas.committed.entries().forEach(([key]) => {
-        if (this.selectBox.contains(key)) {
-          layer.set(key, "");
-        }
-      });
-
-      layer.setFrom(snap(layer, store.currentCanvas.committed));
-
-      store.currentCanvas.setScratchLayer(layer);
-      store.currentCanvas.commitScratch();
+      this.cutSelection();
     }
   }
+
+  /** Switching away from the select tool — drop the selection and any state. */
+  cleanup() {
+    this.selectedCells = [];
+    this.selectBox = undefined;
+    this.activeBox = null;
+    this.attachments = [];
+    this.lineReshape = null;
+    this.moveTool = null;
+    this.dragStart = null;
+    this.dragEnd = null;
+    this.selecting = false;
+    store.currentCanvas.clearSelection();
+    store.currentCanvas.clearScratch();
+  }
+}
+
+function arrowFor(start: Vector, end: Vector, horizontalFirst: boolean) {
+  if (end.x === start.x) {
+    return end.y < start.y ? UNICODE.arrowUp : UNICODE.arrowDown;
+  }
+  if (end.y === start.y) {
+    return end.x < start.x ? UNICODE.arrowLeft : UNICODE.arrowRight;
+  }
+  if (horizontalFirst) {
+    return end.y < start.y ? UNICODE.arrowUp : UNICODE.arrowDown;
+  }
+  return end.x > start.x ? UNICODE.arrowRight : UNICODE.arrowLeft;
+}
+
+function dedupe(cells: Vector[]): Vector[] {
+  const seen = new Set<string>();
+  const result: Vector[] = [];
+  for (const cell of cells) {
+    const key = cell.toString();
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(cell);
+    }
+  }
+  return result;
 }

--- a/client/snap.spec.ts
+++ b/client/snap.spec.ts
@@ -1,0 +1,39 @@
+import { Layer } from "#asciiflow/client/layer";
+import { snap } from "#asciiflow/client/snap";
+import { Vector } from "#asciiflow/client/vector";
+import { expect } from "chai";
+
+describe("snap", () => {
+  it("rebuilds a junction that gains connections from two sides at once", () => {
+    // A horizontal line; the move brings vertical lines against its middle from
+    // both above and below in the same snap pass. The middle must become a full
+    // junction (┼), not just connect to whichever side was processed last.
+    const committed = new Layer();
+    committed.set(new Vector(0, 1), "─");
+    committed.set(new Vector(1, 1), "─");
+    committed.set(new Vector(2, 1), "─");
+
+    const scratch = new Layer();
+    scratch.set(new Vector(1, 0), "│"); // above → wants to connect down
+    scratch.set(new Vector(1, 2), "│"); // below → wants to connect up
+
+    const result = snap(scratch, committed);
+    expect(result.get(new Vector(1, 1))).equals("┼");
+  });
+
+  it("connects a scratch cell to committed neighbours on both sides", () => {
+    // The moving cell (scratch) sits between two committed lines and must end
+    // up connected to both, not just one.
+    const committed = new Layer();
+    committed.set(new Vector(0, 1), "│"); // left wall (connects up/down only)
+    committed.set(new Vector(2, 1), "│"); // right wall
+
+    const scratch = new Layer();
+    scratch.set(new Vector(1, 1), "─"); // a horizontal segment dropped between
+
+    const result = snap(scratch, committed);
+    // The committed walls should each grow a junction toward the new segment.
+    expect(result.get(new Vector(0, 1))).equals("├");
+    expect(result.get(new Vector(2, 1))).equals("┤");
+  });
+});

--- a/client/snap.ts
+++ b/client/snap.ts
@@ -1,14 +1,23 @@
 import {
   connect,
   connectable,
+  connectionGlyph,
   connects,
   disconnect,
+  isArrow,
   isBoxDrawing,
 } from "#asciiflow/client/characters";
 import { Direction } from "#asciiflow/client/direction";
 import { Layer, LayerView } from "#asciiflow/client/layer";
+import { Vector } from "#asciiflow/client/vector";
 
-export function snap(scratch: Layer, committed: Layer) {
+export function snap(
+  scratch: Layer,
+  committed: Layer,
+  // Cells we must NOT normalise — the content being moved/drawn (e.g. a moved
+  // box). We tidy the structure around it, never the thing itself.
+  protect: Set<string> = new Set()
+) {
   const layer = new Layer();
   const modifiedScratch = new LayerView([scratch, layer]);
   for (const position of scratch.keys()) {
@@ -38,15 +47,21 @@ export function snap(scratch: Layer, committed: Layer) {
           connect(modifiedScratch.get(position), [direction])
         );
       }
-      // Connect adjacent box drawing characters to this character.
+      // Connect adjacent box drawing characters to this character. Base this on
+      // the accumulated value so a cell that gains connections from several
+      // neighbours in one pass keeps all of them (e.g. ┼), rather than the last
+      // one clobbering the rest and leaving a side disconnected.
+      const currentAdjacent = layer.has(adjacentPosition)
+        ? layer.get(adjacentPosition)
+        : adjacentValue;
       if (
         connects(value, direction) &&
-        !connects(adjacentValue, direction.opposite()) &&
-        connectable(adjacentValue, direction.opposite())
+        !connects(currentAdjacent, direction.opposite()) &&
+        connectable(currentAdjacent, direction.opposite())
       ) {
         layer.set(
           adjacentPosition,
-          connect(adjacentValue, [direction.opposite()])
+          connect(currentAdjacent, [direction.opposite()])
         );
       }
     }
@@ -66,13 +81,74 @@ export function snap(scratch: Layer, committed: Layer) {
       if (!isBoxDrawing(adjacentValue)) {
         continue;
       }
-      if (connects(adjacentValue, direction.opposite())) {
+      // Accumulate, so a cell next to several deleted cells loses each
+      // connection rather than only the last-processed one.
+      const currentAdjacent = layer.has(adjacentPosition)
+        ? layer.get(adjacentPosition)
+        : adjacentValue;
+      if (connects(currentAdjacent, direction.opposite())) {
         layer.set(
           adjacentPosition,
-          disconnect(adjacentValue, direction.opposite())
+          disconnect(currentAdjacent, direction.opposite())
         );
       }
     }
   }
+
+  // Normalisation pass: make each affected line/junction glyph match the
+  // neighbours it actually connects to. This cleans up the "obviously wrong"
+  // leftovers when cells compete during a move — a ┤ whose left wall left
+  // becomes │, a stray ┼ becomes the right T, a moved box's ├ settles to ┌, etc.
+  const stateAt = (position: Vector) => {
+    const key = position.toString();
+    if (layer.map.has(key)) {
+      const value = layer.map.get(key);
+      return value === "" || value === " " ? null : value;
+    }
+    if (scratch.map.has(key)) {
+      const value = scratch.map.get(key);
+      return value === "" || value === " " ? null : value;
+    }
+    return committed.get(position);
+  };
+
+  // Candidates: the cells touched by this change and their neighbours, EXCEPT
+  // the protected content (the box being moved). This lets generated connectors
+  // and the surrounding structure tidy up, while never mutating what you're
+  // actually moving.
+  const candidates = new Set<string>();
+  const consider = (position: Vector) => {
+    const key = position.toString();
+    if (!protect.has(key)) {
+      candidates.add(key);
+    }
+  };
+  for (const position of scratch.keys()) {
+    consider(position);
+    for (const direction of Direction.ALL) {
+      consider(position.add(direction));
+    }
+  }
+
+  // Two passes so a correction on one cell can inform its neighbour.
+  for (let pass = 0; pass < 2; pass++) {
+    for (const key of candidates) {
+      const position = Vector.fromString(key);
+      const value = stateAt(position);
+      // Only normalise plain line/junction glyphs, never arrows or text.
+      if (!isBoxDrawing(value) || isArrow(value)) {
+        continue;
+      }
+      const dirs = Direction.ALL.filter((direction) => {
+        const neighbour = stateAt(position.add(direction));
+        return isBoxDrawing(neighbour) && connects(neighbour, direction.opposite());
+      });
+      const glyph = connectionGlyph(dirs);
+      if (glyph && glyph !== value) {
+        layer.set(position, glyph);
+      }
+    }
+  }
+
   return layer;
 }

--- a/client/store/canvas.ts
+++ b/client/store/canvas.ts
@@ -47,6 +47,11 @@ export class CanvasStore {
   private _offset: IVector;
   private _scratch: Layer = new Layer();
   private _selection: Box | undefined = undefined;
+  // Selection snapshots tracked alongside the undo/redo layer stacks, plus the
+  // selection captured at the start of the current scratch gesture.
+  private _undoSelections: (Box | undefined)[] = [];
+  private _redoSelections: (Box | undefined)[] = [];
+  private _pendingSelection: Box | undefined = undefined;
 
   // Keys for localStorage persistence.
   private committedKey: string;
@@ -184,17 +189,25 @@ export class CanvasStore {
   }
 
   setScratchLayer(layer: Layer) {
+    // Capture the selection as a gesture begins (empty → non-empty scratch), so
+    // undo can restore it to where it was before the change.
+    if (this._scratch.size() === 0 && layer.size() > 0) {
+      this._pendingSelection = this._selection;
+    }
     this._scratch = layer;
     this.notify();
   }
 
   clear() {
     this._undoLayers = [...this._undoLayers, this.committed];
+    this._undoSelections = [...this._undoSelections, this._selection];
     writePersistent(this.undoKey, this._undoLayers, new ArrayStringifier(Layer));
     this._committed = new Layer();
     writePersistent(this.committedKey, this._committed, Layer);
     this._redoLayers = [];
+    this._redoSelections = [];
     writePersistent(this.redoKey, this._redoLayers, new ArrayStringifier(Layer));
+    this._selection = undefined;
     this.notify();
   }
 
@@ -209,6 +222,8 @@ export class CanvasStore {
     writePersistent(this.committedKey, this._committed, Layer);
     if (undoLayer.size() > 0) {
       this._undoLayers = [...this._undoLayers, undoLayer];
+      // Selection from before this gesture, so undo restores it.
+      this._undoSelections = [...this._undoSelections, this._pendingSelection];
       writePersistent(
         this.undoKey,
         this._undoLayers,
@@ -216,6 +231,7 @@ export class CanvasStore {
       );
     }
     this._redoLayers = [];
+    this._redoSelections = [];
     writePersistent(this.redoKey, this._redoLayers, new ArrayStringifier(Layer));
     this._scratch = new Layer();
     this.notify();
@@ -234,6 +250,11 @@ export class CanvasStore {
     writePersistent(this.redoKey, this._redoLayers, new ArrayStringifier(Layer));
     this._undoLayers = this._undoLayers.slice(0, -1);
     writePersistent(this.undoKey, this._undoLayers, new ArrayStringifier(Layer));
+    // Move the selection through the stack: stash the current one for redo,
+    // restore the one captured before the undone action.
+    this._redoSelections = [...this._redoSelections, this._selection];
+    this._selection = this._undoSelections.at(-1);
+    this._undoSelections = this._undoSelections.slice(0, -1);
     this.notify();
   }
 
@@ -250,6 +271,9 @@ export class CanvasStore {
     writePersistent(this.undoKey, this._undoLayers, new ArrayStringifier(Layer));
     this._redoLayers = this._redoLayers.slice(0, -1);
     writePersistent(this.redoKey, this._redoLayers, new ArrayStringifier(Layer));
+    this._undoSelections = [...this._undoSelections, this._selection];
+    this._selection = this._redoSelections.at(-1);
+    this._redoSelections = this._redoSelections.slice(0, -1);
     this.notify();
   }
 }


### PR DESCRIPTION
## What

Reworks the select tool to be **entity-aware** and makes **snapping** rebuild connections cleanly when shapes move or are drawn.

### Select tool
- **Move a whole box** — grab a box's empty interior and drag. Border + contents move, and attached lines **stay connected and reflow**: straight runs shorten/lengthen, perpendicular moves bend, the connector is traced *through corners* to its real terminal, and arrows pointing *into* the box ride along.
- **Resize a box edge** — grab the border (unchanged `DrawMove`).
- **Reshape a line tip** — drag a free tip and it behaves like the line tool (free 2D, corners), pivoting at the nearest bend; bend orientation follows the segment's own axis (Ctrl/Shift flips).
- **Move a word** — grab a run of text. **Shift-click** to build a multi-selection.
- **Rubber-band** selections reflow lines that cross the selection edge.
- Selection **travels with undo/redo** and is **purged when leaving the tool**.

### Snapping
- **Accumulate connections** so a cell that gains/loses several at once lands on the right junction (no more last-write-wins leaving a side disconnected).
- **Complete the `disconnect` table for `┼`** (DOWN/LEFT/RIGHT) so drawing a line *onto* another yields a **T, not a `+`**.
- **Normalisation pass** — after a change, each affected line/junction is tidied to match its neighbours (a dangling `┤` → `│`, a stray `┼` → the right T, a moved box's connection points settle correctly). Scoped to **never mutate the content being moved**, only the structure around it.
- **Boxes snap to adjacent lines/boxes** when drawn, like lines already did.

## Testing
New specs cover the happy paths and every regression fixed here: `entity.spec`, `select.spec`, `snap.spec`, `box.spec`, `line.spec`, `grid.spec` (incl. a 2x2-grid quadrant move). All client + common suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
